### PR TITLE
fix(evaluation): segmentation figures

### DIFF
--- a/experiments/interpretability-experiments/main-patch-pca.py
+++ b/experiments/interpretability-experiments/main-patch-pca.py
@@ -8,6 +8,8 @@ import argparse
 import torch.nn.functional as F
 from sklearn.preprocessing import MinMaxScaler
 from segmentation_datasets import get_dataset as get_actin_dataset
+from skimage.filters import threshold_otsu
+import copy
 import os
 sys.path.insert(0, "../")
 from DEFAULTS import BASE_PATH
@@ -21,12 +23,27 @@ parser.add_argument("--seed", type=int, default=42)
 parser.add_argument("--dataset", type=str, default="optim")
 parser.add_argument("--model", type=str, default="mae-lightning-small")
 parser.add_argument("--weights", type=str, default="MAE_SMALL_STED")
+parser.add_argument("--threshold", type=str, default=None)
+parser.add_argument("--patch-size", type=int, default=16)
+parser.add_argument("--image-size", type=int, default=224)
 args = parser.parse_args()
 
 def set_seeds():
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
     torch.cuda.manual_seed(args.seed)
+
+def threshold_folder():
+    if args.threshold is None:
+        return "all-patches"
+    elif args.threshold == "foreground":
+        return "foreground-patches"
+    elif args.threshold == "pca1":
+        return "pca1-patches"
+    else:
+        raise NotImplementedError
+
+THRESHOLD_FOLDER = threshold_folder()
 
 def get_save_folder() -> str: 
     if args.weights is None:
@@ -47,26 +64,113 @@ def get_save_folder() -> str:
 def compute_pca(data: np.ndarray, labels: np.ndarray) -> None:
     pca = PCA(n_components=3)
     pca_data = pca.fit_transform(data)
-    pca_per_image = np.split(pca_data, labels.shape[0])
-    return pca_per_image, labels
+    print(pca_data.shape)
+    if args.threshold is None:
+        for ch in range(pca_data.shape[1]):
+            m, M = pca_data[:, ch].min(), pca_data[:, ch].max()
+            pca_data[:, ch] = (pca_data[:, ch] - m) / (M - m)
 
-def show_images(images: np.ndarray, pca_images: list, labels):
-    if not os.path.exists(f"./patch-pca-examples/{args.dataset}"):
+    elif args.threshold == "pca1":
+        indices = np.where(pca_data[:, 0] >= 0)[0]
+        mask = pca_data[:, 0] >= 0
+        assert np.all(pca_data[indices, 0] >=0)
+        for ch in range(pca_data.shape[1]):
+            m, M = pca_data[indices, ch].min(), pca_data[indices, ch].max()
+            pca_data[indices, ch] = (pca_data[indices, ch] - m) / (M - m) 
+
+    else:
+        pass
+
+    pca_per_image = np.reshape(pca_data, (20, 196, 3))
+    pca_mask = np.split(mask, labels.shape[0])
+
+    return pca_per_image, pca_mask, labels
+
+def get_foreground_mask(img: np.ndarray, threshold: float = 0.25):
+    pixel_count = args.patch_size ** 2
+    mask = np.zeros((args.image_size, args.image_size, 3))
+    ys = np.arange(0, args.image_size, args.patch_size)
+    xs = np.arange(0, args.image_size, args.patch_size)
+    for y in ys:
+        for x in xs:
+            patch = img[y:y+args.patch_size, x:x+args.patch_size]
+            patch_tau = patch >= threshold_otsu(patch)
+            foreground = np.count_nonzero(patch_tau)
+            ratio = foreground / pixel_count
+            if ratio >= threshold:
+                mask[y:y+args.patch_size, x:x+args.patch_size] = np.ones((args.patch_size, args.patch_size, 3))
+    return mask
+
+def get_pca_mask(img):
+    img = img.T
+    img = torch.tensor(img, dtype=torch.float32)
+    img = img.view(1, 3, 14, 14)
+    img = img.squeeze(0).cpu().data.numpy()
+    img = np.transpose(img, axes=(1,2,0))
+   
+    assert img.shape == (14, 14, 3)
+    ys = np.arange(0, 224, 16)
+    xs = np.arange(0, 224, 16)
+    mask = np.zeros((args.image_size, args.image_size, 3))
+
+    for i in range(img.shape[0]):
+        for j in range(img.shape[1]):
+            if img[i, j][0] >= 0:
+                y = int(ys[i])
+                x = int(xs[j])
+                mask[y:y+args.patch_size, x:x+args.patch_size] = np.ones((args.patch_size, args.patch_size, 3))
+    return mask
+
+def interpolate_mask(mask):
+    ys = np.arange(0, 224, 16)
+    xs = np.arange(0, 224, 16)
+    intrp_mask = np.zeros((args.image_size, args.image_size, 3))
+    for i in range(mask.shape[0]):
+        for j in range(mask.shape[1]):
+            if mask[i, j] == 1:
+                y = int(ys[i])
+                x = int(xs[j])
+                intrp_mask[y:y+args.patch_size, x:x+args.patch_size] = np.ones((args.patch_size, args.patch_size, 3))
+    return intrp_mask
+
+
+def show_images(images: np.ndarray, pca_images: list, pca_mask: list, labels):
+    if not os.path.exists(f"./patch-pca-examples/{THRESHOLD_FOLDER}/{args.dataset}"):
         print(f"--- Creating directory for {args.dataset} results ---")
-        os.mkdir(f"./patch-pca-examples/{args.dataset}")
+        os.mkdir(f"./patch-pca-examples/{THRESHOLD_FOLDER}/{args.dataset}")
 
-    for i, (og, img) in enumerate(zip(images, pca_images)):
+    for i, (og, img, mask) in enumerate(zip(images, pca_images, pca_mask)):
         label = labels[i]
-        img = MinMaxScaler().fit_transform(img).T
+        img_temp = copy.deepcopy(img)
+        # img = MinMaxScaler().fit_transform(img).T
+        img = img.T
+        mask = mask.T
         img = torch.tensor(img, dtype=torch.float32)
+        mask = torch.tensor(mask, dtype=torch.bool)
+        mask = mask.view(14, 14).detach().cpu().numpy() * 1.0
+        print(mask)
+
         img = img.view(1, 3, 14, 14)
         img = F.interpolate(img, (224, 224), mode='bilinear').squeeze(0).cpu().data.numpy()
+
+        if args.threshold is None:
+            m = np.ones((224, 224, 3))
+        elif args.threshold == "foreground":
+            m = get_foreground_mask(img=og)
+        elif args.threshold == "pca1":
+            print("--- Interpolating patch mask ---")
+            m = interpolate_mask(mask)
+        else: 
+            raise NotImplementedError
+
 
         if og.shape[0] == 3:
             og = og[0]
         # important to convert to numpy and then use np.transpose instead of staying as torch and using torch.view
         # funny business happening when using a combination of torch.view and F.interpolate --> does not give desired RGB image
         img = np.transpose(img, axes=(1, 2, 0)) 
+        img = img * m
+      
         fig = plt.figure()
         ax = fig.add_subplot(121)
         ax2 = fig.add_subplot(122)
@@ -75,8 +179,9 @@ def show_images(images: np.ndarray, pca_images: list, labels):
         ax.set_title(label)
         ax.axis("off")
         ax2.axis("off")
-        fig.savefig(f"./patch-pca-examples/{args.dataset}/{args.weights}-pca-image-{i}.png", dpi=1200, bbox_inches="tight")
+        fig.savefig(f"./patch-pca-examples/{THRESHOLD_FOLDER}/{args.dataset}/{args.weights}-pca-image-{i}.png", dpi=1200, bbox_inches="tight")
         plt.close(fig)
+        exit()
 
 def main():
     SAVENAME = get_save_folder()
@@ -155,8 +260,8 @@ def main():
     og_images = np.concatenate(og_images, axis=0)
     labels = np.array(labels)
 
-    pca_per_image, labels = compute_pca(patch_embeddings, labels)
-    show_images(og_images, pca_per_image, labels)
+    pca_per_image, pca_mask, labels = compute_pca(patch_embeddings, labels)
+    show_images(og_images, pca_per_image, pca_mask, labels)
 
 if __name__=="__main__":
     main()

--- a/experiments/scripts/small-data.sh
+++ b/experiments/scripts/small-data.sh
@@ -75,7 +75,7 @@ echo $numclass
 echo $seed
 echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
 
-python finetune_v2.py --dataset neural-activity-states --model mae-lightning-base --weights $weight --blocks "all" --num-per-class $numclass --seed $seed
+python finetune_v2.py --dataset polymer-rings --model mae-lightning-base --weights $weight --blocks "all" --num-per-class $numclass --seed $seed
 
 echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
 echo "% DONE %"

--- a/experiments/segmentation-experiments/figures/figure-scratch-pretrained.py
+++ b/experiments/segmentation-experiments/figures/figure-scratch-pretrained.py
@@ -4,7 +4,7 @@ import os, glob
 import json
 import argparse
 import sys
-
+from matplotlib.lines import Line2D
 from matplotlib import pyplot
 
 sys.path.insert(0, "../../")
@@ -18,7 +18,7 @@ parser.add_argument("--dataset", type=str,
                     help="Name of the dataset")
 parser.add_argument("--best-model", type=str, default=None, 
                     help="Which model to keep")
-parser.add_argument("--metric", default="auap", type=str,
+parser.add_argument("--metric", default="aupr", type=str,
                     help="Name of the metric to access from the saved file")
 args = parser.parse_args()
 
@@ -72,7 +72,7 @@ def plot_data(pretraining, data, figax=None, position=0, **kwargs):
         values = numpy.array([value[args.metric] for value in values])
         values_masked = numpy.ma.masked_equal(values, -1)
 
-        mean, std = numpy.ma.mean(values, axis=1), numpy.ma.std(values, axis=1)
+        mean, std = numpy.ma.mean(values_masked, axis=1), numpy.ma.std(values_masked, axis=1)
         mean = numpy.mean(mean, axis=-1)
         print(mean)
         averaged.append(mean)
@@ -86,8 +86,7 @@ def plot_data(pretraining, data, figax=None, position=0, **kwargs):
     return (fig, ax)
 
 def main():
-
-    fig, ax = pyplot.subplots(figsize=(4,3))
+    fig, ax = pyplot.subplots()
     modes = ["from-scratch", "pretrained-frozen", "pretrained"]
     pretrainings = ["STED", "HPA", "JUMP", "ImageNet"]
 
@@ -103,8 +102,16 @@ def main():
         xticks=numpy.arange(len(modes)) + width * len(pretrainings) / 2 - 0.5 * width,
     )
     ax.set_xticklabels(modes, rotation=30)
+    legend_elements = [ 
+        Line2D([0], [0], marker='o', color='tab:red', label='ImageNet', markerfacecolor='tab:red'),
+        Line2D([0], [0], marker='o', color='tab:green', label='JUMP', markerfacecolor='tab:green'),
+        Line2D([0], [0], marker='o', color='tab:orange', label='HPA', markerfacecolor='tab:orange'),
+        Line2D([0], [0], marker='o', color='tab:blue', label='STED', markerfacecolor='tab:blue'),
 
-    savefig(fig, os.path.join(".", "results", f"{args.model}_{args.dataset}_scratch-pretrained"), extension="png")
+    ]
+    pyplot.legend(handles=legend_elements)
+
+    savefig(fig, os.path.join(".", "results", f"{args.model}_{args.dataset}_scratch-pretrained"), extension="png", save_white=True)
 
 if __name__ == "__main__":
     main()

--- a/experiments/segmentation-experiments/scripts/train-segmentation-mae-tiny-subsets.sh
+++ b/experiments/segmentation-experiments/scripts/train-segmentation-mae-tiny-subsets.sh
@@ -33,15 +33,15 @@ BACKBONEWEIGHTS=(
     "None"
 )
 OPTS=(
-    "freeze_backbone true batch_size 64"
-    "freeze_backbone false batch_size 64"
-    "freeze_backbone true batch_size 64"
-    "freeze_backbone false batch_size 64"
-    "freeze_backbone true batch_size 64"
-    "freeze_backbone false batch_size 64"        
-    "freeze_backbone true batch_size 64"
-    "freeze_backbone false batch_size 64"
-    "freeze_backbone false batch_size 64"
+    "freeze_backbone true batch_size 32"
+    "freeze_backbone false batch_size 32"
+    "freeze_backbone true batch_size 32"
+    "freeze_backbone false batch_size 32"
+    "freeze_backbone true batch_size 32"
+    "freeze_backbone false batch_size 32"        
+    "freeze_backbone true batch_size 32"
+    "freeze_backbone false batch_size 32"
+    "freeze_backbone false batch_size 32"
 )
 SUBSETS=(
     10

--- a/experiments/segmentation-experiments/scripts/train-segmentation-mae-tiny.sh
+++ b/experiments/segmentation-experiments/scripts/train-segmentation-mae-tiny.sh
@@ -33,15 +33,15 @@ BACKBONEWEIGHTS=(
     "None"
 )
 OPTS=(
-    "freeze_backbone true batch_size 64"
-    "freeze_backbone false batch_size 64"
-    "freeze_backbone true batch_size 64"
-    "freeze_backbone false batch_size 64"
-    "freeze_backbone true batch_size 64"
-    "freeze_backbone false batch_size 64"
-    "freeze_backbone true batch_size 64"
-    "freeze_backbone false batch_size 64"
-    "freeze_backbone false batch_size 64"
+    "freeze_backbone true batch_size 32"
+    "freeze_backbone false batch_size 32"
+    "freeze_backbone true batch_size 32"
+    "freeze_backbone false batch_size 32"
+    "freeze_backbone true batch_size 32"
+    "freeze_backbone false batch_size 32"
+    "freeze_backbone true batch_size 32"
+    "freeze_backbone false batch_size 32"
+    "freeze_backbone false batch_size 32"
 )
 SEEDS=(
     42
@@ -76,7 +76,7 @@ echo "% Options: ${options}"
 echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
 
 tensorboard --logdir="/home/frbea320/projects/def-flavielc/frbea320/flc-dataset/experiments/segmentation-experiments/logs" --host 0.0.0.0 --load_fast false &
-python main.py --seed ${seed} --use-tensorboard --dataset "factin" \
+python main.py --seed ${seed} --use-tensorboard --dataset "lioness" \
     --backbone "mae-lightning-tiny" --backbone-weights ${weight} \
     --opts ${options}
 


### PR DESCRIPTION
Quick fix PR:

- Fix segmentation evaluation script to take average of score values which are not -1. Also change default metric from AUAP to AUPR and added custom legend.
- Added functionality to patch-pca script so that we can filter out background based on a threshold on the first principal component.