### PR TITLE
fix(peroxisome) fixes a multiclass matching pattern

### DIFF
--- a/stedfm/datasets/datasets.py
+++ b/stedfm/datasets/datasets.py
@@ -862,7 +862,7 @@ class PeroxisomeDataset(Dataset):
             files = file.readlines()
             files = [os.path.join(BASE_PATH, file.strip()[1:]) for file in files]
         for i, class_name in enumerate(self.classes):
-            files_list = [f for f in files if class_name in f]
+            files_list = [f for f in files if self._matches_class(f, class_name)]
             original_size += len(files_list)
             self.samples[class_name] = self._get_sampled_files(files_list=files_list, num_sample=num_samples)
 
@@ -880,6 +880,20 @@ class PeroxisomeDataset(Dataset):
             print(f"Class {k} samples: {len(self.samples[k])}")
         print("----------")
         self.info = self.__get_info()
+
+    @staticmethod
+    def _matches_class(path: str, class_name: str) -> bool:
+        """True if ``path`` belongs to growth condition ``class_name``.
+
+        Matches the condition as a *whole* folder token, not a bare substring:
+        each image lives under ``.../<condition>_<replicate>/Nxxx.tiff`` (e.g.
+        ``16hMeOH_1_Duplo``). A naive ``class_name in path`` check is wrong here
+        because ``"6hMeOH"`` is a substring of ``"16hMeOH"``, which would assign
+        every 16hMeOH image to the 6hMeOH class as well (double-counted, with a
+        conflicting label).
+        """
+        folder = os.path.basename(os.path.dirname(path))
+        return folder == class_name or folder.startswith(class_name + "_")
 
     def __balance_classes(self) -> None:
         np.random.seed(42)


### PR DESCRIPTION
This error was found by @Pikauba.

This pull request improves the logic for assigning image files to their correct class in the dataset loader. The main change is the introduction of a more robust method to match files to classes, preventing incorrect double-counting when class names are substrings of each other.

**Class assignment logic improvements:**

* Added a new static method `_matches_class` to ensure files are only assigned to a class if their folder matches the class name exactly or as a prefix followed by an underscore, preventing incorrect matches due to substring overlaps.
* Updated the file filtering logic in the dataset loader's `__init__` method to use `_matches_class` instead of a naive substring check, ensuring correct sample assignment for each class.